### PR TITLE
feat: Add Docker Compose support for deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,49 @@ To deactivate the virtual environment (optional, when you're done working):
 deactivate
 ```
 
+### 1.5. Running with Docker Compose (Recommended)
+
+This is the recommended way to run the application as it encapsulates the environment and simplifies setup.
+
+**Prerequisites:**
+*   Docker Desktop (or Docker Engine + Docker Compose CLI) installed and running.
+
+**Instructions:**
+All commands should be run from the root of the repository (the directory containing the `docker-compose.yml` file and the `card_scheduler_project/` directory).
+
+1.  **Build and Start Services (First Time or After Changes):**
+    This command builds the Docker image for the `web` service (if it doesn't exist or if `Dockerfile` or application code has changed) and starts the service in detached mode (`-d`).
+    ```bash
+    docker-compose up --build -d
+    ```
+
+2.  **Start Services (If Already Built):**
+    If the image is already built and you just want to start the services:
+    ```bash
+    docker-compose up -d
+    ```
+
+3.  **Access the Application:**
+    Once the services are running, open your web browser and navigate to:
+    [http://localhost:5000](http://localhost:5000)
+
+4.  **View Logs:**
+    To view the logs from the `web` service (useful for debugging):
+    ```bash
+    docker-compose logs -f web
+    ```
+    Press `CTRL+C` to stop following the logs.
+
+5.  **Stopping the Services:**
+    To stop and remove the containers, networks, and volumes created by `up`:
+    ```bash
+    docker-compose down
+    ```
+
+**Data Persistence:**
+*   The `docker-compose.yml` is configured to use a volume that maps the `./scheduler_data` directory (in the project root) to the `/app/database` directory inside the container.
+*   This means your SQLite database (`schedule.db`) will be stored in `./scheduler_data` on your host machine and will persist even if you stop or remove the Docker containers. The `scheduler_data` directory will be created automatically if it doesn't exist when the container starts.
+
 ## 2. Project Overview and Requirements
 
 ### 2.1. Project Overview

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3.8'
+
+services:
+  web:
+    build:
+      context: ./card_scheduler_project  # Specifies the directory containing the Dockerfile
+      # dockerfile: Dockerfile # Optional: specify Dockerfile name if not 'Dockerfile'
+    ports:
+      - "5000:5000"  # Maps host port 5000 to container port 5000
+    volumes:
+      # Persists the SQLite database by mapping a host directory to the container directory
+      # where schedule.db is stored.
+      # The WORKDIR in the Dockerfile is /app, and models.py creates the database in
+      # a 'database' subdirectory. So, the path inside the container is /app/database.
+      - ./scheduler_data:/app/database
+    # Optional: Add environment variables if needed by the application
+    # environment:
+    #   - FLASK_ENV=development # Example
+
+# Optional: Define a top-level named volume if you prefer named volumes over host paths.
+# For this MVP, a host path mapping is simpler and sufficient.
+# volumes:
+#   scheduler_db_data: # This would then be used as "scheduler_db_data:/app/database" in the service.


### PR DESCRIPTION
This commit introduces Docker Compose configuration to simplify the deployment and management of the Card Scheduler application.

Changes include:
- Created `docker-compose.yml` in the project root:
    - Defines a `web` service for the Flask application.
    - Specifies the build context to use the existing Dockerfile in `card_scheduler_project/`.
    - Maps host port 5000 to container port 5000.
    - Configures a host-mapped volume (`./scheduler_data:/app/database`) to ensure persistence of the SQLite database (`schedule.db`) across container restarts.

- Updated `README.md`:
    - Added a new subsection "1.5. Running with Docker Compose (Recommended)" under "Setup and Running the Application".
    - Provides clear instructions and commands for building, starting (detached mode), stopping the application, and viewing logs using `docker-compose`.
    - Explains the data persistence mechanism for the database via the mapped volume.

This enhancement allows you to easily run the application in a containerized environment, consistent with the deployment strategy mentioned in the project requirements.