### PR TITLE
fix: Update host port to 5003 and remove obsolete compose version

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ All commands should be run from the root of the repository (the directory contai
 
 3.  **Access the Application:**
     Once the services are running, open your web browser and navigate to:
-    [http://localhost:5000](http://localhost:5000)
+    [http://localhost:5003](http://localhost:5003)
 
 4.  **View Logs:**
     To view the logs from the `web` service (useful for debugging):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,10 @@
-version: '3.8'
-
 services:
   web:
     build:
       context: ./card_scheduler_project  # Specifies the directory containing the Dockerfile
       # dockerfile: Dockerfile # Optional: specify Dockerfile name if not 'Dockerfile'
     ports:
-      - "5000:5000"  # Maps host port 5000 to container port 5000
+      - "5003:5000"  # Maps host port 5003 to container port 5000
     volumes:
       # Persists the SQLite database by mapping a host directory to the container directory
       # where schedule.db is stored.


### PR DESCRIPTION
Addresses a "port already allocated" error when running with Docker Compose by changing the host port mapping from 5000 to 5003. The container still exposes port 5000, but the host will now listen on 5003.

Also removes the obsolete `version: '3.8'` attribute from `docker-compose.yml` as per modern Docker Compose standards.

The `README.md` has been updated to reflect these changes, instructing you to access the application on port 5003 when using Docker Compose.